### PR TITLE
Fix BIP44 key derivation path

### DIFF
--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -673,7 +673,7 @@ is_bip32_key = lambda x: is_xprv(x) or is_xpub(x)
 
 def bip44_derivation(account_id, segwit=False):
     bip  = 49 if segwit else 44
-    coin = 1 if bitcoin.NetworkConstants.TESTNET else 0
+    coin = 1 if bitcoin.NetworkConstants.TESTNET else 8
     return "m/%d'/%d'/%d'" % (bip, coin, int(account_id))
 
 def from_seed(seed, passphrase, is_p2sh):

--- a/plugins/digitalbitbox/digitalbitbox.py
+++ b/plugins/digitalbitbox/digitalbitbox.py
@@ -675,7 +675,7 @@ class DigitalBitboxPlugin(HW_PluginBase):
         client = devmgr.client_by_id(device_id)
         client.handler = self.create_handler(wizard)
         client.setupRunning = True
-        client.get_xpub("m/44'/0'", 'standard')
+        client.get_xpub("m/44'/8'", 'standard')
 
 
     def is_mobile_paired(self):

--- a/plugins/ledger/ledger.py
+++ b/plugins/ledger/ledger.py
@@ -499,7 +499,7 @@ class LedgerPlugin(HW_PluginBase):
         device_id = device_info.device.id_
         client = devmgr.client_by_id(device_id)
         client.handler = self.create_handler(wizard)
-        client.get_xpub("m/44'/0'", 'standard') # TODO replace by direct derivation once Nano S > 1.1
+        client.get_xpub("m/44'/8'", 'standard') # TODO replace by direct derivation once Nano S > 1.1
 
     def get_xpub(self, device_id, derivation, xtype, wizard):
         devmgr = self.device_manager()


### PR DESCRIPTION
As per SLIP44 Feathercoin's coin type is 8.
Since Electrum wallets are interoperable between cryptocurrencies, this needs to be corrected to prevent key reuse.
Is there are a constant set already for the testnet keypath?