### PR TITLE
Fix magic message for consistency with core

### DIFF
--- a/electrum/ecc.py
+++ b/electrum/ecc.py
@@ -300,7 +300,7 @@ class ECPubkey(object):
 def msg_magic(message: bytes) -> bytes:
     from .bitcoin import var_int
     length = bfh(var_int(len(message)))
-    return b"\x19Feathercoin Signed Message:\n" + length + message
+    return b"\x1cFeathercoin Signed Message:\n" + length + message
 
 
 def verify_message_with_address(address: str, sig65: bytes, message: bytes):

--- a/electrum/tests/test_bitcoin.py
+++ b/electrum/tests/test_bitcoin.py
@@ -172,8 +172,8 @@ class Test_bitcoin(SequentialTestCase):
         sig1_b64 = base64.b64encode(sig1)
         sig2_b64 = base64.b64encode(sig2)
 
-        self.assertEqual(sig1_b64, b'IMJ177QE+PonT9RcqHL5/aFjo635kMmE6sDi9PAtvqm1PaqCVU16L0Mb3d64z7nNnrDpVWa+2UqaQ1r2oqEkgsE=')
-        self.assertEqual(sig2_b64, b'HOrxiXh8D4ddJSG2x3oV7OVYSOC45DuLst/uS+G3tc70OZyuqet67q1r+7fKDXEBkhTSXbt+gl+iC7/okXLXYec=')
+        self.assertEqual(sig1_b64, b'H0YLLJku6jqtfMAiDHHlY9Dr7blntXd0T7CPGLfKm0XtWjleM+DJ5HCgRs55EdQsj6KL0v0TjsuVI7Ij3//X84E=')
+        self.assertEqual(sig2_b64, b'GweSYB1TXaNWFIo4eOGDLUvtvMcAB5rwXDGQIm3al/22PsERMOLz+pl1fjuV4zCBI7ERqPHfmXZxF3G+3UZyBuQ=')
 
         self.assertTrue(ecc.verify_message_with_address(addr1, sig1, msg1))
         self.assertTrue(ecc.verify_message_with_address(addr2, sig2, msg2))


### PR DESCRIPTION
magic message was inconsistent with feathercoind due to wrong consideration of its length. Described in #106 . This is now fixed.